### PR TITLE
ServiceDetail - add address prop component

### DIFF
--- a/src/components/Address/Address.js
+++ b/src/components/Address/Address.js
@@ -1,0 +1,31 @@
+import React from "react";
+import styled from "styled-components";
+
+export const AddressList = styled.li`
+    display: flex;
+    align-items: center;
+    &::before {
+        // TODO
+        font-family: "Font Awesome 5 Free";
+        content: "\f007";
+        margin-right: 10px;
+    }
+`;
+
+const Address = (props) => {
+    const { address } = props;
+
+    return(
+        <AddressList key={address.uprn}>
+            <a href={`https://maps.google.com/?q=${address.address1}%20${address.address2}%20${address.city}%20${address.stateProvince}%20${address.postalCode}`} target="_blank">
+                {address.address1}<br></br>
+                {address.address2 ? address.address2 + ", " : ""}
+                {address.city ? address.city + ", " : ""}
+                {address.stateProvince ? address.stateProvince + ", " : ""}
+                {address.postalCode ? address.postalCode : ""}
+            </a>
+        </AddressList>
+    );
+}
+
+export default Address;

--- a/src/components/Service/ServiceDetail.js
+++ b/src/components/Service/ServiceDetail.js
@@ -35,8 +35,6 @@ export const DetailContainer = styled.div`
 
 const GreyInnerContainer = styled(InnerContainer)`
     background: #F8F8F8;
-<<<<<<< Updated upstream
-=======
     margin-bottom: 15px;
     &.info {
         h2 {
@@ -52,7 +50,6 @@ const GreyInnerContainer = styled(InnerContainer)`
             margin-top: 0;
         }
     }
->>>>>>> Stashed changes
 `;
 
 const ServiceDetail = () => {
@@ -92,9 +89,9 @@ const ServiceDetail = () => {
                 <h2>{data.name}</h2>
                 <p>{data.description}</p>
                 <h3>This is for:</h3>
-                <div>
+                <p>
                     {data.demographic.map(d => d.name).reduce((prev, curr) => [prev, ', ', curr])}
-                </div>
+                </p>
             </GreyInnerContainer>
             <InnerContainer>
                 <div>   
@@ -126,8 +123,8 @@ const ServiceDetail = () => {
             <InnerContainer>
                 <h3>Address</h3>
                 <ul className="ul-no-style">
-                    {data.locations.map(location =>
-                        <Address address={location} />
+                    {data.locations.map((location, index) =>
+                        <Address key={index} address={location} />
                     )}
                 </ul>
             </InnerContainer>

--- a/src/components/Service/ServiceDetail.js
+++ b/src/components/Service/ServiceDetail.js
@@ -6,6 +6,7 @@ import { darken } from "polished";
 import breakpoint from 'styled-components-breakpoint';
 import { InnerContainer } from "../../util/styled-components/InnerContainer";
 import UrlParamsContext from "../../context/UrlParamsContext/UrlParamsContext";
+import Address from "../Address/Address";
 
 export const DetailContainer = styled.div`
     ${breakpoint('md')`
@@ -34,6 +35,24 @@ export const DetailContainer = styled.div`
 
 const GreyInnerContainer = styled(InnerContainer)`
     background: #F8F8F8;
+<<<<<<< Updated upstream
+=======
+    margin-bottom: 15px;
+    &.info {
+        h2 {
+            margin-bottom: 10px;
+        }
+        h3 {
+            font-size: 16px;
+            margin-bottom: 5px;
+        }
+        p {
+            font-size: 16px;
+            color: #525A5B;
+            margin-top: 0;
+        }
+    }
+>>>>>>> Stashed changes
 `;
 
 const ServiceDetail = () => {
@@ -60,7 +79,6 @@ const ServiceDetail = () => {
         hero = data.images.medium;
     }
   
-    console.log(data);
     return isLoading ? (
             <AppLoading />
         ) : (
@@ -108,14 +126,8 @@ const ServiceDetail = () => {
             <InnerContainer>
                 <h3>Address</h3>
                 <ul className="ul-no-style">
-                    {/* TODO - a href */}
                     {data.locations.map(location =>
-                    <li>
-                        <a href={`geo:${location.latitude},${location.longitude}`} target="_blank">
-                            {location.address1}<br></br>
-                            {location.address2}, {location.city}, {location.stateProvince}, {location.postalCode}
-                        </a>
-                    </li>
+                        <Address address={location} />
                     )}
                 </ul>
             </InnerContainer>

--- a/src/util/styled-components/InnerContainer.js
+++ b/src/util/styled-components/InnerContainer.js
@@ -2,8 +2,5 @@ import styled from "styled-components";
 import breakpoint from 'styled-components-breakpoint';
 
 export const InnerContainer = styled.div`
-    padding: 20px 15px;
-    ${breakpoint('md')`
-        
-    `}
+    padding: 15px;
 `;


### PR DESCRIPTION
Please check PR 1 first https://github.com/LBHackney-IT/lbh-fss-public-frontend/pull/1

**Example URL**
http://localhost:3000/?service=7
This service will display 2 addresses, the 2nd without a address2 prop (and comma)
You can also check other IDs too

**Figma**
Section 03

**Components to check**
- Address section
- Check address is displaying correctly with / without full address details (id 7 example)
- Clicking on each address will open google map with the address passed (might not work with the mock data as it's a mixture of random address details)

**Task**
https://app.clickup.com/t/9e5u61