### PR TITLE
Phase 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3485,11 +3485,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        }
       }
     },
     "axobject-query": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@reach/router": "^1.3.4",
     "actionsheet-react": "^1.0.9",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "cross-env": "^7.0.2",
     "history": "^5.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,8 @@ import UrlParamsContext from "./context/UrlParamsContext/UrlParamsContext";
 import PrevUrlParamsContext from "./context/PrevUrlParamsContext/PrevUrlParamsContext";
 import MapToggleContext from "./context/MapToggleContext/MapToggleContext";
 import AppLoading from './AppLoading';
-import { SidebarContainer } from "./util/styled-components/SidebarContainer"
+import { SidebarContainer } from "./util/styled-components/SidebarContainer";
+import { postcodeValidator, postcodeValidatorExists } from 'postcode-validator';
 import {ThemeProvider} from 'styled-components';
 import "react-leaflet-markercluster/dist/styles.min.css";
 
@@ -56,7 +57,18 @@ function App() {
       setIsLoading(false);
     }
     storeQuery();
+
   }, [setUrl, setPrevUrl, setUrlParams, setIsLoading]);
+
+  // rewrite postcode param if changed from url
+  if (Object.keys(urlParams).length !== 0) {
+    let postcode = [urlParams].find(postcode => postcode);
+    postcode = postcode.postcode;
+    const validPostcode = postcodeValidator(postcode, 'UK');
+    if (validPostcode) {
+      localStorage.setItem("postcode", postcode);
+    }
+  }
 
   return (
     isLoading ? <AppLoading /> :

--- a/src/components/Back/Back.js
+++ b/src/components/Back/Back.js
@@ -34,9 +34,6 @@ const Back = () => {
     const {urlParams, setUrlParams} = useContext(UrlParamsContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
     const storedPostcode = localStorage.getItem("postcode");
-    const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
-    const currentSearch = window.location.search;
-    let paramObj = {};
     
     const prevUrlArrayLast = prevUrl[prevUrl.length - 1];
     const prevUrlParamsArrayLast = prevUrlParams[prevUrlParams.length - 1];
@@ -113,7 +110,8 @@ const Back = () => {
                     }
                 // else if a middlelayer page i.e. setting postcode, selecting categories or demographics
                 } else if ((key == "set_postcode" || key == "select_categories" || key == "select_demographics") && value == "true") {
-                    push = prevUrlArrayLast;
+                    delete prevUrlParamsArrayLast["select_demographics"];
+                    push = "?" + new URLSearchParams(prevUrlParamsArrayLast).toString();
                     params = prevUrlParamsArrayLast;
                 }
                 // anything else (category explorer / list services) will use default route
@@ -144,7 +142,6 @@ const Back = () => {
                     if (listServicesSearchObj !== undefined && listServicesSearchObj.service_search !== undefined) {
                         serviceSearch = listServicesSearchObj.service_search;
                     }
-                    console.log(storedPostcode);
                     if (storedPostcode) {
                         postcodeValue = storedPostcode;
                     }

--- a/src/components/Back/Back.js
+++ b/src/components/Back/Back.js
@@ -37,17 +37,6 @@ const Back = () => {
     const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
     const currentSearch = window.location.search;
     let paramObj = {};
-
-    function createParamObj(currentSearch, paramsArray) {
-        const queryParts = currentSearch.substring(1).split(/[&;]/g);
-        const arrayLength = queryParts.length;
-        for (let i = 0; i < arrayLength; i++) {
-            const queryKeyValue = queryParts[i].split("=");
-            if (paramsArray.includes(queryKeyValue[0])) {
-                paramObj[queryKeyValue[0]] = queryKeyValue[1];
-            } 
-        }
-    }
     
     const prevUrlArrayLast = prevUrl[prevUrl.length - 1];
     const prevUrlParamsArrayLast = prevUrlParams[prevUrlParams.length - 1];

--- a/src/components/Back/Back.js
+++ b/src/components/Back/Back.js
@@ -129,6 +129,54 @@ const Back = () => {
                 }
                 // anything else (category explorer / list services) will use default route
             }
+        } else {
+            const selectDemographicsObj = [urlParams].find(selectDemographicsObj => selectDemographicsObj.select_demographics);
+            const selectCategoriesObj = [urlParams].find(selectCategoriesObj => selectCategoriesObj.select_categories);
+            const demographicObj = [urlParams].find(demographicObj => demographicObj.demographic);
+            const categoriesObj = [urlParams].find(categoriesObj => categoriesObj.categories);
+            const categoryExplorerObj = [urlParams].find(categoryExplorerObj => categoryExplorerObj.category_explorer);
+            const listServicesSearchObj = [urlParams].find(listServicesSearchObj => listServicesSearchObj.service_search);
+            const listServicesPostcodeObj = [urlParams].find(listServicesPostcodeObj => listServicesPostcodeObj.postcode);
+            if (selectDemographicsObj || selectCategoriesObj) {
+                let selectedDemographics = undefined;
+                let selectedCategories = undefined;
+                let serviceSearch = '';
+                let postcodeValue = null;
+                if (demographicObj) {
+                    selectedDemographics = demographicObj.demographic;
+                }
+                if (categoriesObj) {
+                    selectedCategories = categoriesObj.category;
+                }
+                if (categoryExplorerObj) {
+                    params = {"category_explorer": categoryExplorerObj.category_explorer, "demographic": selectedDemographics, "categories": selectedCategories};
+                }
+                if (listServicesSearchObj || listServicesPostcodeObj) {
+                    if (listServicesSearchObj !== undefined && listServicesSearchObj.service_search !== undefined) {
+                        serviceSearch = listServicesSearchObj.service_search;
+                    }
+                    console.log(storedPostcode);
+                    if (storedPostcode) {
+                        postcodeValue = storedPostcode;
+                    }
+                    params = {"service_search": serviceSearch, "postcode": postcodeValue, "demographic": selectedDemographics, "categories": selectedCategories};
+                }
+                // if (listServicesSearchObj && listServicesPostcodeObj) {
+                //     params = {"service_search": listServicesSearchObj.service_search, "postcode": listServicesPostcodeObj.postcode, "demographic": selectedDemographics, "categories": selectedCategories};
+                // } else if (listServicesSearchObj) {
+                //     params = {"service_search": listServicesSearchObj.service_search, "demographic": selectedDemographics, "categories": selectedCategories};
+                // } else if (listServicesPostcodeObj) {
+                //     params = {"postcode": listServicesPostcodeObj.postcode, "demographic": selectedDemographics, "categories": selectedCategories};
+                // }
+            }
+            if (!params.demographic) {
+                delete params["demographic"];
+            }
+            if (!params.categories) {
+                delete params["categories"];
+            }
+            push = "?" + new URLSearchParams(params).toString().replace(/%2C/g,"+").replace(/%2B/g,"+");
+            push = push.replaceAll("=undefined", "");
         }
         
         history.push(push);

--- a/src/components/Category/CategoryExplorer.js
+++ b/src/components/Category/CategoryExplorer.js
@@ -18,6 +18,7 @@ import { useMediaQuery } from 'react-responsive';
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
 import { light } from "../../settings";
 import { lighten } from 'polished';
+import { handleSetPrevUrl } from "../../util/functions/handleSetPrevUrl";
 
 export const FILTER_MODIFIER = {
     grey: () => `
@@ -53,9 +54,6 @@ const CategoryExplorer = ({ category, onClick }) => {
   const {prevUrl, setPrevUrl} = useContext(PrevUrlContext);
   const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
   const {mapToggle, setMapToggle} = useContext(MapToggleContext);
-  const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
-  const currentSearch = window.location.search;
-  let paramObj = {};
   const [showMap, setShowMap] = useState("false");
   const [fetchOnce, setfetchOnce] = useState(false);
 
@@ -67,17 +65,6 @@ const CategoryExplorer = ({ category, onClick }) => {
   const Mobile = ({ children }) => {
     const isMobile = useMediaQuery({ maxWidth: 767 })
     return isMobile ? children : null
-  }
-
-  function createParamObj(currentSearch, paramsArray) {
-    const queryParts = currentSearch.substring(1).split(/[&;]/g);
-    const arrayLength = queryParts.length;
-    for (let i = 0; i < arrayLength; i++) {
-      const queryKeyValue = queryParts[i].split("=");
-      if (paramsArray.includes(queryKeyValue[0])) {
-        paramObj[queryKeyValue[0]] = queryKeyValue[1];
-      }
-    }
   }
   
   useEffect(() => {
@@ -108,20 +95,12 @@ const CategoryExplorer = ({ category, onClick }) => {
       setfetchOnce(true);
     }
     
-    if (prevUrl.length == 0 && prevUrlParams.length == 0) {
-      let prevUrlArray = [""];
-      let prevUrlParamsArray = [{}];
-
-      // setPrevUrl
-      if (currentSearch) {
-        prevUrlArray.push(currentSearch);
-        setPrevUrl(prevUrlArray);
-      }
-
-      // setPrevUrlParams
-      createParamObj(currentSearch, paramsArray);
-      prevUrlParamsArray.push(paramObj);
-      setPrevUrlParams(prevUrlParamsArray);
+    const setPrevUrlVals = handleSetPrevUrl({
+      prevUrl, prevUrlParams
+    });
+    if (setPrevUrlVals) {
+      setPrevUrl(setPrevUrlVals.prevUrlArray);
+      setPrevUrlParams(setPrevUrlVals.prevUrlParamsArray);
     }
 
     if (mapToggle === "true") {

--- a/src/components/Category/CategoryExplorer.js
+++ b/src/components/Category/CategoryExplorer.js
@@ -16,6 +16,14 @@ import {MapContainer} from "../../util/styled-components/MapContainer";
 import HackneyMap from "../HackneyMap/HackneyMap";
 import { useMediaQuery } from 'react-responsive';
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
+import { light } from "../../settings";
+import { lighten } from 'polished';
+
+export const FILTER_MODIFIER = {
+    grey: () => `
+        background: ${lighten(0.09, light["greyBorder"])};
+    `,
+}
 
 export const CategoryCardContainer = styled.div`
   .fss--card {
@@ -146,13 +154,13 @@ const CategoryExplorer = ({ category, onClick }) => {
       ) : (
         <div>
           <Header />
-          <ServiceFilter />
           <CategoryCardContainer>
             <CategoryCard
               key={categoryData.id}
               category={categoryData}
             />
           </CategoryCardContainer>
+          <ServiceFilter modifiers="grey" />
           <Mobile>
             <ToggleView />
             {

--- a/src/components/Category/ListCategories.js
+++ b/src/components/Category/ListCategories.js
@@ -9,10 +9,13 @@ import { light } from "../../settings";
 export const ListCategoriesContainer = styled.div`
     ${breakpoint('md')`
       position: relative;
-      top: 216px;
       z-index: 2;
       background: ${light["white"]};
     `}
+    h3 {
+      font-weight: normal;
+      font-size: 24px;
+    }
 `;
 
 const ListCategories = ({ categories = [], onClick }) => {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -6,16 +6,25 @@ import PrevUrlContext from "../../context/PrevUrlContext/PrevUrlContext";
 import UrlParamsContext from "../../context/UrlParamsContext/UrlParamsContext";
 import PrevUrlParamsContext from "../../context/PrevUrlParamsContext/PrevUrlParamsContext";
 import styled from "styled-components";
-import { green } from "../../settings";
+import { green, light } from "../../settings";
 
 const HeaderContainer = styled.div`
     display: flex;
     background: ${green["main"]};
     justify-content: space-between;
+    align-items: center;
     height: 60px;
     border-bottom: 1px solid ${green["light"]};
     position: relative;
     z-index: 1;
+    h2 {
+        color: ${light["white"]};
+        font-weight: normal;
+        font-size: 24px;
+        letter-spacing: -0.0175em;
+        margin-bottom: 0;
+        margin-left: 15px;
+    }
 `;
 
 const Header = () => {  
@@ -24,16 +33,19 @@ const Header = () => {
     const {urlParams, setUrlParams} = useContext(UrlParamsContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
     let showPostcodeButton = true;
+    let isHome = true;
+    const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic", "set_postcode", "select_categories", "select_demographics", "map_toggle"];
 
     for (const [key, value] of Object.entries(urlParams)) {
-        if ((key == "set_postcode" || key == "select_categories" || key == "select_demographics") && value == "true") {
+        isHome = false;
+        if (key == "set_postcode") {
             showPostcodeButton = false;
         }
     }
 
     return (
         <HeaderContainer className="no-print">
-            <Back />
+            {(isHome) ? <h2>Find support services</h2> : <Back />}
             {(showPostcodeButton) ? <PostcodeButton /> : ""}
         </HeaderContainer>
     );

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -5,6 +5,7 @@ import UrlContext from "../../context/UrlContext/UrlContext";
 import PrevUrlContext from "../../context/PrevUrlContext/PrevUrlContext";
 import UrlParamsContext from "../../context/UrlParamsContext/UrlParamsContext";
 import PrevUrlParamsContext from "../../context/PrevUrlParamsContext/PrevUrlParamsContext";
+import Header from "../Header/Header";
 import FormInput from "../FormInput/FormInput";
 import FormInputSubmit from "../FormInputSubmit/FormInputSubmit";
 import Button from "../Button/Button";
@@ -18,19 +19,12 @@ import { green, light } from "../../settings";
 import breakpoint from 'styled-components-breakpoint';
 
 const HomeHeader = styled.div`
-    padding: 25px 15px 10px;
+    padding: 17px 15px 2px;
     background: ${green["main"]};
     z-index: 1;
     ${breakpoint('md')`
-        position: absolute;
+        position: relative;
     `}
-    h2 {
-        color: ${light["white"]};
-        font-weight: normal;
-        font-size: 36px;
-        letter-spacing: -0.0175em;
-        margin-bottom: 15px;
-    }
 `;
 
 const Home = () => {
@@ -95,62 +89,26 @@ const Home = () => {
         setQuery({ category_explorer: ~~ e }, 'pushIn');
         storeQuery();
         const currentSearch = window.location.search;
-        setPreviousUrls(currentSearch);
-        
+        setPreviousUrls(currentSearch);  
     };
 
-    async function submitForm({ postcode, service_search }) {
+    async function submitForm({ service_search }) {
         if (isLoading) return;
 
-        const postcodeValue = document.forms["fss--find-service"]["postcode"].value;
-        const searchValue = document.forms["fss--find-service"]["service_search"].value;
-        const validPostcode = postcodeValidator(postcode, 'UK');
-
-        if (postcodeValue !== "" && searchValue !== "") {
-            if (validPostcode) {
-                history.push("?postcode=" + postcode + "&service_search=" + service_search);
-                const currentSearch = window.location.search;   
-                setPreviousUrls(currentSearch);
-                setUrlParams({postcode: postcode, service_search: service_search});
-            } else {
-                let node = document.createElement("p");
-                let textNode = document.createTextNode("Please enter a valid postcode");
-                node.appendChild(textNode);
-                document.getElementById("postcode-input-container").appendChild(node);
-            }
-        } else if (postcodeValue !== "") {
-            if (validPostcode) {
-                localStorage.setItem("postcode", postcode);
-                history.push("?postcode=" + postcode + "&service_search");
-                const currentSearch = window.location.search;
-                setPreviousUrls(currentSearch);
-                setUrlParams({postcode: postcode, service_search: undefined});
-            } else {
-                let node = document.createElement("p");
-                node.className = "postcode-validation-error-message";
-                let textNode = document.createTextNode("Please enter a valid postcode");
-                node.appendChild(textNode);
-
-                let pList = document.getElementsByTagName("p");
-                for(var i=pList.length-1; i>=0; i--){
-                    let p = pList[i];
-                    if(p.className === "postcode-validation-error-message"){
-                        p.parentNode.removeChild(p);
-                    }
-                }
-
-                document.getElementById("postcode-input-container").appendChild(node);
-                document.getElementById("list-categories--container").style.top = "258px";
-                document.getElementById("list-categories--container").firstChild.style.height = "calc(100vh - 300px)";
-            }
-            
-        } else if (searchValue !== "") {
-            history.push("?postcode&service_search=" + service_search);
-            const currentSearch = window.location.search;
-            setPreviousUrls(currentSearch);
-            setUrlParams({postcode: undefined, service_search: service_search});
-            localStorage.removeItem('postcode');
+        let postcodeQuery = storedPostcode;
+        if (!storedPostcode) {
+            postcodeQuery = undefined;
         }
+
+        let searchQuery = service_search;
+        if (service_search === "") {
+            searchQuery = undefined;
+        }
+
+        history.push("?postcode=" + storedPostcode + "&service_search=" + service_search);
+        const currentSearch = window.location.search;
+        setPreviousUrls(currentSearch);
+        setUrlParams({postcode: postcodeQuery, service_search: searchQuery});
     }
 
     return (
@@ -159,21 +117,9 @@ const Home = () => {
         ) : (
             <>
             <div className="Home">
+                <Header />
                 <HomeHeader>
-                    <h2>Find support services</h2>
                     <form id="fss--find-service" onSubmit={handleSubmit(submitForm)} data-testid="form">
-                        <div id="postcode-input-container">
-                            <FormInput
-                                id="fss--postcode"
-                                label="Enter a postcode"
-                                placeholder="Enter full postcode e.g E8 1DY (optional)"
-                                name="postcode"
-                                inputRef={postcodeRef}
-                                register={register}
-                                defaultValue={storedPostcode}
-                                autoComplete="off"
-                            />
-                        </div>
                         <FormInputSubmit
                             id="fss--service-search"
                             label="Search for a service"

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -32,11 +32,9 @@ const Home = () => {
     const {prevUrl, setPrevUrl} = useContext(PrevUrlContext);
     const {urlParams, setUrlParams} = useContext(UrlParamsContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
-    const [{ category_explorer }, setQuery] = useQueryParams({ category_explorer: NumberParam });
     const [isLoading, setIsLoading] = useState(true);
     const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
     const { register, handleSubmit, errors, reset } = useForm();
-    const postcodeRef = useRef();
     const currentSearch = window.location.search;
     const storedPostcode = localStorage.getItem("postcode");
     let prevUrlArray = [""];
@@ -52,17 +50,6 @@ const Home = () => {
                 paramObj[queryKeyValue[0]] = queryKeyValue[1];
             } 
         }
-    }
-
-    const storeQuery = (e) => {
-        const currentSearch = window.location.search;
-        if (currentSearch) {
-            setUrl(currentSearch);
-            createParamObj(currentSearch, paramsArray);
-            
-            setUrlParams(paramObj);
-        }
-        setIsLoading(false);
     }
 
     const setPreviousUrls = (currentSearch) => {
@@ -85,20 +72,14 @@ const Home = () => {
         setIsLoading(false);
     }, [setIsLoading]);
 
-    const handleEvent = e => {
-        setQuery({ category_explorer: ~~ e }, 'pushIn');
-        storeQuery();
-        const currentSearch = window.location.search;
-        setPreviousUrls(currentSearch);  
-    };
+    let postcodeQuery = storedPostcode;
+    if (!storedPostcode) {
+        postcodeQuery = undefined;
+    }
 
+    // keyword search
     async function submitForm({ service_search }) {
         if (isLoading) return;
-
-        let postcodeQuery = storedPostcode;
-        if (!storedPostcode) {
-            postcodeQuery = undefined;
-        }
 
         let searchQuery = service_search;
         if (service_search === "") {
@@ -106,10 +87,16 @@ const Home = () => {
         }
 
         history.push("?postcode=" + storedPostcode + "&service_search=" + service_search);
-        const currentSearch = window.location.search;
         setPreviousUrls(currentSearch);
         setUrlParams({postcode: postcodeQuery, service_search: searchQuery});
     }
+
+    // category explorer
+    const selectCategory = e => {
+        history.push("?category_explorer=" + e + "&postcode=" + postcodeQuery);
+        setUrlParams({category_explorer: e, postcode: postcodeQuery});
+        setPreviousUrls(currentSearch);  
+    };
 
     return (
         isLoading ? (
@@ -130,7 +117,7 @@ const Home = () => {
                         />
                     </form>
                 </HomeHeader>
-                <ListCategories onClick={handleEvent} />
+                <ListCategories onClick={selectCategory} />
                 <MapPlaceholder />
             </div>
             </>

--- a/src/components/Postcode/PostcodeButton.js
+++ b/src/components/Postcode/PostcodeButton.js
@@ -9,15 +9,17 @@ import history from '../../history';
 import { green, light } from "../../settings";
 
 const PostcodeButtonContainer = styled.button`
+    display: flex;
+    align-items: center;
+    width: 112px;
+    height: 100%;
     background: ${green["dark"]};
     color: ${light["white"]};
     border: 0;
-    padding: 10px 15px;
+    padding: 10px 13px;
     cursor: pointer;
-    display: flex;
-    align-items: center;
-    width: 130px;
     text-align: left;
+    font-size: 14px;
     &.postcode-set {
         background: ${green["dark"]};
         padding: 20px 15px;
@@ -28,7 +30,7 @@ const PostcodeButtonContainer = styled.button`
         font-family: "Font Awesome 5 Duotone";
         font-weight: 900;
         content: "\f3c5";
-        margin-right: 10px;
+        margin-right: 5px;
     }
     svg {
         margin-right: 10px;

--- a/src/components/Postcode/SetPostcode.js
+++ b/src/components/Postcode/SetPostcode.js
@@ -75,13 +75,15 @@ const SetPostcode = () => {
                 push = prevUrlArrayLast;
                 params = prevUrlParamsArrayLast;
 
+                
+
                 // checking if previous page is support_service
-                if (prevUrlParamsArrayLast.support_service !== undefined) {
+                if (prevUrlParamsArrayLast && prevUrlParamsArrayLast.support_service !== undefined) {
                     //
                 } else {
                 // catch all for list services
-                    const ListServicesSearchObj = prevUrlParams.find(ListServicesSearchObj => ListServicesSearchObj.service_search);
-                    let ListServicesPostcodeObj = prevUrlParams.find(ListServicesPostcodeObj => ListServicesPostcodeObj.postcode);
+                    const ListServicesSearchObj = [prevUrlParamsArrayLast].find(ListServicesSearchObj => ListServicesSearchObj.service_search);
+                    let ListServicesPostcodeObj = [prevUrlParamsArrayLast].find(ListServicesPostcodeObj => ListServicesPostcodeObj.postcode);
                     prevUrlParamsArrayLast["postcode"] = postcode;
                     if (ListServicesSearchObj !== undefined) {
                     // if service_search exists in prevUrlParams

--- a/src/components/Postcode/SetPostcode.js
+++ b/src/components/Postcode/SetPostcode.js
@@ -99,6 +99,11 @@ const SetPostcode = () => {
                         params = ListServicesPostcodeObj;
                     }
                 }
+            } else {
+                // redirect the user back to home
+                // when setting a postcode from the home page
+                push = "/?";
+                params = {};
             }
 
             history.push(push);

--- a/src/components/RouteContainer/RouteContainer.js
+++ b/src/components/RouteContainer/RouteContainer.js
@@ -38,7 +38,7 @@ const RouteContainer = (props) => {
                     setPage("CategoryExplorer");
                 } else if (key == "support_service" && value !== "") {
                     setPage("ServiceDetail");
-                } else if (key == "postcode" && value !== "" || key == "service_search" && value !== "") {
+                } else if (key == "service_search") {
                     setPage("ListServices");
                 } else if (key == "service_search_process" && value == "true") {
                     setPage("ServiceSearchProcess");

--- a/src/components/RouteContainer/RouteContainer.js
+++ b/src/components/RouteContainer/RouteContainer.js
@@ -30,7 +30,11 @@ const RouteContainer = (props) => {
     useEffect(() => {
         async function checkQuery() {
             for (const [key, value] of Object.entries(urlParams)) {
-                if (key == "category_explorer" && value !== "") {
+                if (key == "select_demographics" && value == "true") {
+                    setPage("SelectDemographics");
+                // } else if (key == "select_categories" && value == "true") {
+                //     setPage("SelectCategories");
+                } else if (key == "category_explorer" && value !== "") {
                     setPage("CategoryExplorer");
                 } else if (key == "support_service" && value !== "") {
                     setPage("ServiceDetail");
@@ -40,10 +44,6 @@ const RouteContainer = (props) => {
                     setPage("ServiceSearchProcess");
                 } else if (key == "set_postcode" && value == "true") {
                     setPage("SetPostcode");
-                } else if (key == "select_categories" && value == "true") {
-                    setPage("SelectCategories");
-                } else if (key == "select_demographics" && value == "true") {
-                    setPage("SelectDemographics");
                 }
             }
         }

--- a/src/components/SelectCategories/SelectCategories.js
+++ b/src/components/SelectCategories/SelectCategories.js
@@ -17,6 +17,7 @@ import { dark, red, light } from "../../settings";
 import {FilterContainer} from "../../util/styled-components/FilterContainer";
 import {CheckboxContainer} from "../../util/styled-components/CheckboxContainer";
 import FormCheckbox from "../FormCheckbox/FormCheckbox";
+import ServiceSearch from '../ServiceSearch/ServiceSearch';
 import ServiceFilter from '../ServiceFilter/ServiceFilter';
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
 
@@ -119,6 +120,7 @@ const SelectCategories = () => {
             <>
             <FilterContainer>
                 <Header />
+                <ServiceSearch />
                 <ServiceFilter />
                 <h2>Select categories</h2>
                 <form onSubmit={handleSubmit(submitForm)} data-testid="form">

--- a/src/components/SelectCategories/SelectCategories.js
+++ b/src/components/SelectCategories/SelectCategories.js
@@ -20,6 +20,7 @@ import FormCheckbox from "../FormCheckbox/FormCheckbox";
 import ServiceSearch from '../ServiceSearch/ServiceSearch';
 import ServiceFilter from '../ServiceFilter/ServiceFilter';
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
+import { handleSetPrevUrl } from "../../util/functions/handleSetPrevUrl";
 
 const StyledButton = styled(Button)`
     width: 100%;
@@ -34,9 +35,7 @@ const SelectCategories = () => {
     const {urlParams, setUrlParams} = useContext(UrlParamsContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
     const [isLoading, setIsLoading] = useState(true);
-    const paramsArray = ["category_explorer", "postcode" , "service_search", "support_service"];
     const storedPostcode = localStorage.getItem("postcode");
-    const currentSearch = window.location.search;    
     const prevUrlArrayLast = prevUrl[prevUrl.length - 1];
     const prevUrlParamsArrayLast = prevUrlParams[prevUrlParams.length - 1];
 
@@ -64,6 +63,12 @@ const SelectCategories = () => {
     }
     defaultValues = selectedObj;
 
+    let listServicesSearchObj, listServicesPostcodeObj = null;
+    if (urlParams !== 0) {
+        listServicesSearchObj = [urlParams].find(listServicesSearchObj => listServicesSearchObj.service_search);
+        listServicesPostcodeObj = [urlParams].find(listServicesPostcodeObj => listServicesPostcodeObj.postcode);
+    }
+
     const { register, handleSubmit } = useForm({
         defaultValues: defaultValues,
     });
@@ -75,13 +80,24 @@ const SelectCategories = () => {
             setIsLoading(false);
         }
     
-        // if directly accessing this page redirect user back to home
-        if (prevUrl.length == 0 && prevUrlParams.length == 0) {
-            history.push("?");
-            setUrl("");
-            setUrlParams({});
-        } else {
-            fetchData();
+        // if directly accessing this page
+        // without category_explorer / service_search / postcode passed
+        // redirect user back to home
+        if (prevUrl.length === 0 && prevUrlParams.length === 0) {
+            if (!(listServicesSearchObj || listServicesPostcodeObj)) {
+                history.push("?");
+                setUrl("");
+                setUrlParams({});
+            }
+        }
+        fetchData();
+
+        const setPrevUrlVals = handleSetPrevUrl({
+            prevUrl, prevUrlParams
+        });
+        if (setPrevUrlVals) {
+            setPrevUrl(setPrevUrlVals.prevUrlArray);
+            setPrevUrlParams(setPrevUrlVals.prevUrlParamsArray);
         }
     
     }, [setData, setIsLoading]);

--- a/src/components/SelectDemographics/SelectDemographics.js
+++ b/src/components/SelectDemographics/SelectDemographics.js
@@ -11,9 +11,11 @@ import FormError from "../FormError/FormError";
 import Button from "../Button/Button";
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
+import { applyStyleModifiers } from 'styled-components-modifiers';
 import { postcodeValidator, postcodeValidatorExists } from 'postcode-validator';
 import history from '../../history';
-import { dark, red, light } from "../../settings";
+import { green, dark, red, light } from "../../settings";
+import breakpoint from 'styled-components-breakpoint';
 import {FilterContainer} from "../../util/styled-components/FilterContainer";
 import {CheckboxContainer} from "../../util/styled-components/CheckboxContainer";
 import FormCheckbox from "../FormCheckbox/FormCheckbox";
@@ -23,10 +25,31 @@ import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
 import CategoryCard from "../Category/CategoryCard";
 import CategoryExplorer from "../Category/CategoryExplorer";
 
+export const BUTTON_MODIFIERS = {
+    ghost: () => `
+        position: absolute;
+        top: -50px;
+        left: 180px;
+        width: auto;
+        padding: 8px;
+        color: ${green["main"]};
+        background: transparent;
+        border: 1px solid ${green["ghost"]};
+        font-size: 16px;
+        &:hover, &:focus {
+            color: ${light["white"]};
+        }
+        @media(min-width:768px) {
+            top: -44px;
+        }
+    `,
+}
+
 const StyledButton = styled(Button)`
     width: 100%;
     border-radius: 3px;
     border-bottom: 2px solid ${dark["black"]};
+    ${applyStyleModifiers(BUTTON_MODIFIERS)};
 `;
 
 export const CategoryCardContainer = styled.div`
@@ -172,8 +195,9 @@ const SelectDemographics = () => {
                 </CategoryCardContainer>
                 }
                 <ServiceFilter />
-                <h2>Select demographics</h2>
+                <h2>Select filters</h2>
                 <form onSubmit={handleSubmit(submitForm)} data-testid="form">
+                    <StyledButton modifiers="ghost" type="submit" label="Apply" disabled={isLoading} />
                     <CheckboxContainer>
                         {data.map((demographic, index) => {
                             const demographicIdString = demographic.id.toString();
@@ -189,7 +213,7 @@ const SelectDemographics = () => {
                                 />
                             );
                         })}
-                        <StyledButton type="submit" label="Select filters" disabled={isLoading} />
+                        <StyledButton type="submit" label="Apply filters" disabled={isLoading} />
                     </CheckboxContainer>
                 </form>
             </FilterContainer>

--- a/src/components/SelectDemographics/SelectDemographics.js
+++ b/src/components/SelectDemographics/SelectDemographics.js
@@ -182,6 +182,8 @@ const SelectDemographics = () => {
         history.push(push);
         setUrl(push);
         setUrlParams(urlParams);
+        setPrevUrl([push]);
+        setPrevUrlParams([urlParams]);
     }
 
     return (

--- a/src/components/SelectDemographics/SelectDemographics.js
+++ b/src/components/SelectDemographics/SelectDemographics.js
@@ -24,6 +24,7 @@ import ServiceFilter from '../ServiceFilter/ServiceFilter';
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
 import CategoryCard from "../Category/CategoryCard";
 import CategoryExplorer from "../Category/CategoryExplorer";
+import { handleSetPrevUrl } from "../../util/functions/handleSetPrevUrl";
 
 export const BUTTON_MODIFIERS = {
     ghost: () => `
@@ -148,6 +149,14 @@ const SelectDemographics = () => {
             }
         }
         fetchData();
+
+        const setPrevUrlVals = handleSetPrevUrl({
+            prevUrl, prevUrlParams
+        });
+        if (setPrevUrlVals) {
+            setPrevUrl(setPrevUrlVals.prevUrlArray);
+            setPrevUrlParams(setPrevUrlVals.prevUrlParamsArray);
+        }
     
     }, [setData, setCategoryData, setIsLoading]);
 

--- a/src/components/Service/ListServices.js
+++ b/src/components/Service/ListServices.js
@@ -15,6 +15,7 @@ import { useMediaQuery } from 'react-responsive';
 import HackneyMap from "../HackneyMap/HackneyMap";
 import MapPlaceholder from "../MapPlaceholder/MapPlaceholder";
 import ServiceSearch from '../ServiceSearch/ServiceSearch';
+import { handleSetPrevUrl } from "../../util/functions/handleSetPrevUrl";
 
 const ListServices = ({ onClick }) => {
   const [data, setData] = useState([]);
@@ -23,9 +24,6 @@ const ListServices = ({ onClick }) => {
   const {prevUrl, setPrevUrl} = useContext(PrevUrlContext);
   const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
   const {mapToggle, setMapToggle} = useContext(MapToggleContext);
-  const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
-  const currentSearch = window.location.search;
-  let paramObj = {};
   const [showMap, setShowMap] = useState("false");
   const [fetchOnce, setfetchOnce] = useState(false);
 
@@ -37,17 +35,6 @@ const ListServices = ({ onClick }) => {
   const Mobile = ({ children }) => {
     const isMobile = useMediaQuery({ maxWidth: 767 })
     return isMobile ? children : null
-  }
-
-  function createParamObj(currentSearch, paramsArray) {
-    const queryParts = currentSearch.substring(1).split(/[&;]/g);
-    const arrayLength = queryParts.length;
-    for (let i = 0; i < arrayLength; i++) {
-      const queryKeyValue = queryParts[i].split("=");
-      if (paramsArray.includes(queryKeyValue[0])) {
-        paramObj[queryKeyValue[0]] = queryKeyValue[1];
-      } 
-    }
   }
 
   useEffect(() => {
@@ -77,20 +64,12 @@ const ListServices = ({ onClick }) => {
       setfetchOnce(true);
     }
 
-    if (prevUrl.length == 0 && prevUrlParams.length == 0) {
-      let prevUrlArray = [""];
-      let prevUrlParamsArray = [{}];
-
-      // setPrevUrl
-      if (currentSearch) {
-        prevUrlArray.push(currentSearch);
-        setPrevUrl(prevUrlArray);
-      }
-
-      // setPrevUrlParams
-      createParamObj(currentSearch, paramsArray);
-      prevUrlParamsArray.push(paramObj);
-      setPrevUrlParams(prevUrlParamsArray);
+    const setPrevUrlVals = handleSetPrevUrl({
+      prevUrl, prevUrlParams
+    });
+    if (setPrevUrlVals) {
+      setPrevUrl(setPrevUrlVals.prevUrlArray);
+      setPrevUrlParams(setPrevUrlVals.prevUrlParamsArray);
     }
 
     if (mapToggle === "true") {

--- a/src/components/Service/ServiceDetail.js
+++ b/src/components/Service/ServiceDetail.js
@@ -26,6 +26,7 @@ import {MapContainer} from "../../util/styled-components/MapContainer";
 import HackneyMap from "../HackneyMap/HackneyMap";
 import { useMediaQuery } from 'react-responsive';
 import ReactToPrint from 'react-to-print';
+import { handleSetPrevUrl } from "../../util/functions/handleSetPrevUrl";
 
 export const DetailContainer = styled.div`
     .service-info {
@@ -253,10 +254,7 @@ const ServiceDetail = () => {
     const {urlParams} = useContext(UrlParamsContext);
     const {prevUrl, setPrevUrl} = useContext(PrevUrlContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
-    const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
-    const currentSearch = window.location.search;
     const storedPostcode = localStorage.getItem("postcode");
-    let paramObj = {};
 
     useEffect(() => {
         async function fetchData() {
@@ -273,20 +271,12 @@ const ServiceDetail = () => {
         }
         fetchData();
 
-        if (prevUrl.length == 0 && prevUrlParams.length == 0) {
-            let prevUrlArray = [""];
-            let prevUrlParamsArray = [{}];
-
-            // setPrevUrl
-            if (currentSearch) {
-                prevUrlArray.push(currentSearch);
-                setPrevUrl(prevUrlArray);
-            }
-
-            // setPrevUrlParams
-            createParamObj(currentSearch, paramsArray);
-            prevUrlParamsArray.push(paramObj);
-            setPrevUrlParams(prevUrlParamsArray);
+        const setPrevUrlVals = handleSetPrevUrl({
+            prevUrl, prevUrlParams
+        });
+        if (setPrevUrlVals) {
+            setPrevUrl(setPrevUrlVals.prevUrlArray);
+            setPrevUrlParams(setPrevUrlVals.prevUrlParamsArray);
         }
 
     }, [setData, setIsLoading]);
@@ -299,17 +289,6 @@ const ServiceDetail = () => {
     const Mobile = ({ children }) => {
         const isMobile = useMediaQuery({ maxWidth: 767 })
         return isMobile ? children : null
-    }
-
-    function createParamObj(currentSearch, paramsArray) {
-        const queryParts = currentSearch.substring(1).split(/[&;]/g);
-        const arrayLength = queryParts.length;
-        for (let i = 0; i < arrayLength; i++) {
-            const queryKeyValue = queryParts[i].split("=");
-            if (paramsArray.includes(queryKeyValue[0])) {
-                paramObj[queryKeyValue[0]] = queryKeyValue[1];
-            } 
-        }
     }
 
     let hero = "";

--- a/src/components/ServiceFilter/ServiceFilter.js
+++ b/src/components/ServiceFilter/ServiceFilter.js
@@ -10,6 +10,15 @@ import history from '../../history';
 import { green, yellow, light } from "../../settings";
 import { lighten } from 'polished';
 
+export const BAR_MODIFIERS = {
+    grey: () => `
+        background: ${lighten(0.01, light["greyBorder"])};
+        button {
+            color: ${green["main"]}
+        }
+    `,
+}
+
 export const ServiceFilterContainer = styled.div`
     background: ${lighten(0.03, green["main"])};
     width: 100%;
@@ -18,6 +27,7 @@ export const ServiceFilterContainer = styled.div`
     align-items: center;
     position: relative;
     z-index: 1;
+    ${applyStyleModifiers(BAR_MODIFIERS)};
 `;
 
 export const BUTTON_MODIFIERS = {
@@ -42,7 +52,7 @@ const FilterButton = styled.button`
         display: none;
         font-family: "Font Awesome 5 Pro";
         font-weight: 900;
-        content: "\f03a";
+        content: "\f0b0";
     }
     svg {
         margin-right: 10px;
@@ -66,29 +76,38 @@ const ServiceFilter = ({onClick}) => {
     const {prevUrl, setPrevUrl} = useContext(PrevUrlContext);
     const {urlParams, setUrlParams} = useContext(UrlParamsContext);
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
-    const pathCategories = "?select_categories=true";
-    const pathDemographics = "?select_demographics=true";
+    const prevUrlArrayLast = prevUrl[prevUrl.length - 1];
+    const prevUrlParamsArrayLast = prevUrlParams[prevUrlParams.length - 1];
+    let push = "?" + new URLSearchParams(prevUrlParamsArrayLast).toString().replace(/%2C/g,"+");
+    let params = prevUrlParamsArrayLast;
+    const pathCategories = "&select_categories=true";
+    const pathDemographics = "&select_demographics=true";
     let showCategoriesButton = true;
     let showDemographicsButton = true;
     let showClearAllButton = false;
     let style = "";
+    let grey = "";
 
     const selectCategoriesEvent = e => {
-        for (const [key, value] of Object.entries(urlParams)) {
-            if (key !== "select_categories" && value !== "true") {
-                history.push(pathCategories);
-                setUrl(pathCategories);
-                setUrlParams({"select_categories": "true"});
-            }
+        const selectCategoriesObj = [urlParams].find(selectCategoriesObj => selectCategoriesObj.select_categories);
+        if (!selectCategoriesObj) {
+            let push = "?" + new URLSearchParams(urlParams).toString().replace(/%2C/g,"+").replace(/%2B/g,"+") + pathCategories;
+            push = push.replaceAll("=undefined", "");
+            history.push(push);
+            setUrl(push);
+            urlParams["select_categories"] = "true";
+            setUrlParams(urlParams);
         }
     };
     const selectDemographicsEvent = e => {
-        for (const [key, value] of Object.entries(urlParams)) {
-            if (key !== "select_demographics" && value !== "true") {
-                history.push(pathDemographics);
-                setUrl(pathDemographics);
-                setUrlParams({"select_demographics": "true"});
-            }
+        const selectDemographicsObj = [urlParams].find(selectDemographicsObj => selectDemographicsObj.select_demographics);
+        if (!selectDemographicsObj) {
+            let push = "?" + new URLSearchParams(urlParams).toString().replace(/%2C/g,"+").replace(/%2B/g,"+") + pathDemographics;
+            push = push.replaceAll("=undefined", "");
+            history.push(push);
+            setUrl(push);
+            urlParams["select_demographics"] = "true";
+            setUrlParams(urlParams);
         }
     };
     const clearTaxonomiesEvent = e => {
@@ -100,11 +119,11 @@ const ServiceFilter = ({onClick}) => {
             }
         }
     };
-    
 
     for (const [key, value] of Object.entries(urlParams)) {
         if (key == "category_explorer" && value !== "") {
             showCategoriesButton = false;
+            grey = "grey";
         }
         if (key == "select_categories" && value === "true") {
             showDemographicsButton = false;
@@ -119,13 +138,13 @@ const ServiceFilter = ({onClick}) => {
     }
 
     return (
-        <ServiceFilterContainer>
-            {(showCategoriesButton) ?
+        <ServiceFilterContainer modifiers={grey}>
+            {/* {(showCategoriesButton) ?
                 <FilterButton modifiers={style} onClick={selectCategoriesEvent}>
                     Categories
-                </FilterButton> : ""}
+                </FilterButton> : ""} */}
             {(showDemographicsButton) ?
-                <FilterButton modifiers={style} modifiers="filter" onClick={selectDemographicsEvent}>
+                <FilterButton modifiers={style} onClick={selectDemographicsEvent}>
                     Filters
                 </FilterButton> : ""}
             {(showClearAllButton) ?

--- a/src/components/ServiceSearch/ServiceSearch.js
+++ b/src/components/ServiceSearch/ServiceSearch.js
@@ -56,7 +56,6 @@ const ServiceSearch = ({onClick}) => {
         prevUrlParamsArrayLast["service_search"] = searchValue;
         prevUrlParamsArray.push(prevUrlParamsArrayLast);
         setPrevUrlParams(prevUrlParamsArray);
-
         setUrlParams({"service_search_process": "true"});
 
     }

--- a/src/components/ServiceSearch/ServiceSearch.js
+++ b/src/components/ServiceSearch/ServiceSearch.js
@@ -47,9 +47,6 @@ const ServiceSearch = ({onClick}) => {
         setIsLoading(false);
     });
 
-    console.log(prevUrl);
-    console.log(prevUrlParams);
-
     async function submitForm() {
         if (isLoading) return;
 

--- a/src/components/ServiceSearch/ServiceSearch.js
+++ b/src/components/ServiceSearch/ServiceSearch.js
@@ -47,6 +47,9 @@ const ServiceSearch = ({onClick}) => {
         setIsLoading(false);
     });
 
+    console.log(prevUrl);
+    console.log(prevUrlParams);
+
     async function submitForm() {
         if (isLoading) return;
 

--- a/src/components/ServiceSearch/ServiceSearch.js
+++ b/src/components/ServiceSearch/ServiceSearch.js
@@ -6,10 +6,10 @@ import UrlParamsContext from "../../context/UrlParamsContext/UrlParamsContext";
 import PrevUrlParamsContext from "../../context/PrevUrlParamsContext/PrevUrlParamsContext";
 import { useForm } from "react-hook-form";
 import FormInputSubmit from "../FormInputSubmit/FormInputSubmit";
-import { green, yellow, light } from "../../settings";
+import { green, yellow, light, dark } from "../../settings";
 
 export const ServiceSearchContainer = styled.div`
-    background: ${green["main"]};;
+    background: ${green["main"]};
     width: 100%;
     display: flex;
     align-items: center;
@@ -23,6 +23,28 @@ export const ServiceSearchContainer = styled.div`
             margin-bottom: 0;
         }
     }
+    .searched {
+        input[type="text"] {
+            color: ${dark["greyLight"]};
+            opacity: 0.95;
+            &:focus {
+                color: ${dark["black"]};
+                opacity: 1;
+                button {
+                    opacity: 1;
+                }
+                ~ button {
+                    opacity: 1;
+                }
+            }
+        }
+        button {
+            opacity: 0.5;
+            &:hover, &:focus {
+                opacity: 1;
+            }
+        }
+    }
 `;
 
 const ServiceSearch = ({onClick}) => {
@@ -32,11 +54,10 @@ const ServiceSearch = ({onClick}) => {
     const {prevUrlParams, setPrevUrlParams} = useContext(PrevUrlParamsContext);
     const { register, handleSubmit, errors, reset } = useForm();
     const [isLoading, setIsLoading] = useState(true);
-    const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
-    const storedPostcode = localStorage.getItem("postcode");
     const [searchTerm, setSearchTerm] = useState("");
     const prevUrlArrayLast = prevUrl[prevUrl.length - 1];
     const prevUrlParamsArrayLast = prevUrlParams[prevUrlParams.length - 1];
+    const [hasSearch, setHasSearch] = useState("");
 
     useEffect(() => {
         for (const [key, value] of Object.entries(urlParams)) {
@@ -45,13 +66,16 @@ const ServiceSearch = ({onClick}) => {
             }
         }
         setIsLoading(false);
+
+        let searchValue = document.forms["fss--find-service"]["service_search"].value;
+        if (searchValue) {
+            setHasSearch("searched");
+        }
     });
 
     async function submitForm() {
         if (isLoading) return;
-
         let searchValue = document.forms["fss--find-service"]["service_search"].value;
-
         let prevUrlParamsArray = prevUrlParams;
         prevUrlParamsArrayLast["service_search"] = searchValue;
         prevUrlParamsArray.push(prevUrlParamsArrayLast);
@@ -62,7 +86,7 @@ const ServiceSearch = ({onClick}) => {
 
     return (
         <ServiceSearchContainer>
-            <form id="fss--find-service" onSubmit={handleSubmit(submitForm)} data-testid="form">
+            <form id="fss--find-service" onSubmit={handleSubmit(submitForm)} data-testid="form" className={hasSearch}>
                 <FormInputSubmit
                     id="fss--service-search"
                     label="Search for a service"

--- a/src/components/ServiceSearch/ServiceSearchProcess.js
+++ b/src/components/ServiceSearch/ServiceSearchProcess.js
@@ -13,6 +13,7 @@ const ServiceSearchProcess = () => {
     const searchValue = prevUrlParamsArrayLast["service_search"];
     
     prevUrlParamsArrayLast["service_search"] = searchValue;
+    delete prevUrlParamsArrayLast["select_demographics"];
     let push = "?" + new URLSearchParams(prevUrlParamsArrayLast).toString().replace(/%2520/g,"");
     push = push.replaceAll("=undefined", "");
     history.push(push);

--- a/src/helpers/GlobalStyle/GlobalStyle.js
+++ b/src/helpers/GlobalStyle/GlobalStyle.js
@@ -84,6 +84,10 @@ a {
   }
 }
 
+button {
+	cursor: pointer;
+}
+
 ul.ul-no-style {
   list-style: none;
   padding-left: 0;

--- a/src/services/BaseApiUrl/BaseApiUrl.js
+++ b/src/services/BaseApiUrl/BaseApiUrl.js
@@ -1,7 +1,15 @@
-// staging
-// const BASE_API_URL =
-//     "https://xx0z3bot52.execute-api.eu-west-2.amazonaws.com/staging/api/v1";
-// production
-const BASE_API_URL =
-    "https://qtv3g90mcf.execute-api.eu-west-2.amazonaws.com/production/api/v1";
+let BASE_API_URL = "";
+
+const location = window.location.origin;
+
+if (location.includes("find-support-services.hackney")) {
+  BASE_API_URL = `https://qtv3g90mcf.execute-api.eu-west-2.amazonaws.com/production/api/v1`;
+} else if (location.includes("find-support-services-staging.hackney")) {
+  BASE_API_URL = `https://xx0z3bot52.execute-api.eu-west-2.amazonaws.com/staging/api/v1`;
+} else {
+  // BASE_API_URL = `https://qtv3g90mcf.execute-api.eu-west-2.amazonaws.com/production/api/v1`;
+  BASE_API_URL = `https://xx0z3bot52.execute-api.eu-west-2.amazonaws.com/staging/api/v1`;
+//   BASE_API_URL = "/api";
+}
+
 export default BASE_API_URL;

--- a/src/services/GetServices/GetServices.js
+++ b/src/services/GetServices/GetServices.js
@@ -16,7 +16,12 @@ const GetServices = {
       if (Array.isArray(taxonomyids[0])) {
         taxonomyids = taxonomyids[0];
       } else {
-        taxonomyids = taxonomyids[0].split("+");
+        taxonomyids[0] = taxonomyids[0].toString();
+        if (taxonomyids[0].indexOf('+') > -1) {
+          taxonomyids = taxonomyids[0].split("+");
+        } else {
+          taxonomyids = taxonomyids[0];
+        }
       }
     } else if (taxonomyids.length > 1) {
       // check if elements are array and convert to string by +

--- a/src/util/functions/handleSetPrevUrl.js
+++ b/src/util/functions/handleSetPrevUrl.js
@@ -1,0 +1,33 @@
+function handleSetPrevUrl({prevUrl, prevUrlParams}){
+    const paramsArray = ["category_explorer", "postcode", "service_search", "support_service", "categories", "demographic"];
+    const currentSearch = window.location.search;
+    let paramObj = {};
+
+    if (prevUrl.length == 0 && prevUrlParams.length == 0) {
+        let prevUrlArray = [""];
+        let prevUrlParamsArray = [{}];
+
+        // setPrevUrl
+        if (currentSearch) {
+            prevUrlArray.push(currentSearch);
+        }
+
+        // setPrevUrlParams
+        const queryParts = currentSearch.substring(1).split(/[&;]/g);
+        const arrayLength = queryParts.length;
+        for (let i = 0; i < arrayLength; i++) {
+            const queryKeyValue = queryParts[i].split("=");
+            if (paramsArray.includes(queryKeyValue[0])) {
+                paramObj[queryKeyValue[0]] = queryKeyValue[1];
+            } 
+        }
+
+        prevUrlParamsArray.push(paramObj);
+
+        return {prevUrlArray, prevUrlParamsArray};
+    }
+
+    return;
+}
+
+export { handleSetPrevUrl };

--- a/src/util/styled-components/CardContainer.js
+++ b/src/util/styled-components/CardContainer.js
@@ -7,7 +7,7 @@ export const CardContainer = styled.div`
     ${breakpoint('md')`
         padding: 20px 15px 20px;
         overflow-y: scroll;
-        height: calc(100vh - 260px);
+        height: calc(100vh - 200px);
         position: relative;
         z-index: 1;
         background: ${light["white"]};

--- a/src/util/styled-components/CheckboxContainer.js
+++ b/src/util/styled-components/CheckboxContainer.js
@@ -6,6 +6,6 @@ export const CheckboxContainer = styled.div`
     ${breakpoint('md')`
         padding: 0 15px;
         overflow-y: scroll;
-        height: calc(100vh - 225px);
+        height: calc(100vh - 320px);
     `}
 `;

--- a/src/util/styled-components/FilterContainer.js
+++ b/src/util/styled-components/FilterContainer.js
@@ -3,7 +3,6 @@ import breakpoint from 'styled-components-breakpoint';
 import { light } from "../../settings";
 
 export const FilterContainer = styled.div`
-    
     ${breakpoint('md')`
         position: relative;
         z-index: 1;
@@ -12,5 +11,8 @@ export const FilterContainer = styled.div`
     `}
     h2 {
         margin: 30px 15px 15px !important;
+    }
+    form {
+        position: relative;
     }
 `;


### PR DESCRIPTION
## Task
- https://app.clickup.com/t/awx0by
- Please see description for AC

## Setup
- Change your local `BASE_API_URL` to use `staging` in `src/services/BaseApiUrl/BaseApiUrl.js`
- `npm i && yarn start`

## Figma
- https://www.figma.com/file/t6fanDKvLkCHJsY85ivFTF/Services-Directory?node-id=2641%3A68607

## Test 1: set postcode & search
1. - [ ] Ensure you don't have a postcode saved (use incognito)
1. - [ ] Visit the home screen
1. - [ ] Click on the postcode button in top right
1. - [ ] Set a valid UK postcode
1. - [ ] You should be redirected back to the home screen
1. - [ ] Ensure the postcode you set is shown in the top right button (use e18dy if you like)
1. - [ ] Click the search icon without a keyword
1. - [ ] Ensure services are shown - url should read along the lines of ?postcode={value}&service_search=

## Test 2: Set keyword and filter
1. Continue from test 1
1. - [ ] You can submit a keyword search of 'food' or 'bank' from the service listing screen results are refined (url ~?postcode={value}&service_search=food)
1. - [ ] You navigate to the filter screen and check a button and 'apply' and be returned to the service listing screen and presented with a smaller number of results which include your keyword + the filter you selected (url ~?postcode={value}&service_search={value}&demographic={value})
1. - [ ] Vice versa too, the results will be the same if you start from http://localhost:3000/?postcode=bs50fe&service_search= - submit filter - submit keyword search from service listing screen
1. - [ ] Then you can change the keyword from the service listing screen, return a different set of results while still have the filter applied (url ~?postcode={value}&service_search={newValue}&demographic={value})
1. - [ ] However if you navigate to the filter screen, select some boxes (don't apply) and change and submit the keyword search here then it will not apply the newly selected boxes (uses different form elements)

## Test 3: Set postcode from filter screen
1. Navigate by any means to the filter screen
1. - [ ] Ensure the postcode button is present in the top right
1. - [ ] Click through and set a new valid postcode and you should be redirected not back to the main service listing screen you came from, that is, if you used the search then you should be redirected to the search service listing screen; if you came from the category explorer then redirected to the category explorer service listing screen. Point being is it doesn't take you back to the filter screen

## Test 4: quick tests
1. Directly access http://localhost:3000/?postcode=e18dy&service_search=&select_demographics=true & toggle 'back' and 'filters' a few times
    - [ ] Expected result: Start of filter screen; services listed with no keyword; filter screen; services listed with no keyword; filter screen etc
1. Directly access http://localhost:3000/?category_explorer=8&postcode=e18dy&select_demographics=true & toggle 'back' and filters' a few times
    - [ ] Expected result: Similar to above, but category explorer listing screen
1. Directly access http://localhost:3000/?category_explorer=8&postcode=e18dy&demographic=14 & navigate to filter screen, uncheck the existing one and select another
    - [ ] Expected result: Redirected back to category explorer listing and different results shown based on new filter
1. Directly access http://localhost:3000/?postcode=bs50ee&service_search=food&demographic=16 & (same as above) navigate to filter screen, uncheck the existing one and select another
    - [ ] Expected result: Redirected back to keyword service listing and different results shown based on new filter

Let me know if you have any questions