### PR TITLE
Hotfix/Back button fix to prevent loss of category Id.

### DIFF
--- a/src/util/functions/handleSetPrevUrl.js
+++ b/src/util/functions/handleSetPrevUrl.js
@@ -3,7 +3,7 @@ function handleSetPrevUrl({prevUrl, prevUrlParams}){
     const currentSearch = window.location.search;
     let paramObj = {};
 
-    if (prevUrl.length == 0 && prevUrlParams.length == 0) {
+    if (prevUrl.length == 0 && prevUrlParams.length == 0 || (currentSearch && prevUrl.length > 0 && prevUrl[prevUrl.length - 1] != currentSearch)) 
         let prevUrlArray = [""];
         let prevUrlParamsArray = [{}];
 


### PR DESCRIPTION
Steps to reproduce:
1.	From the homepage, use the 'category explorer' under the keyword search on screen 1 and click on Loneliness or Isolation category.
2.	Click on a listing.
3.	Click on Back button and you are correctly in Loneliness or Isolation.
4.	Click on Back button again to take you to the home page.
5.	Click on Anxiety or Mental Health category.
6.	Click on a listing.
7.	Click on Back button expecting to go back to Anxiety or Mental Health but now you are back on Loneliness or Isolation.
