### PR TITLE
Test/coverage reporters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
           command: yarn test:ci
           environment:
             CI: "true"
-            NODE_OPTIONS: "--max-old-space-size=4096"          
+            NODE_OPTIONS: "--max-old-space-size=4096"
             JEST_JUNIT_OUTPUT_DIR: test_results
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,8 @@ jobs:
           name: Run Tests
           command: yarn test:ci
           environment:
+            CI: "true"
+            NODE_OPTIONS: "--max-old-space-size=4096"          
             JEST_JUNIT_OUTPUT_DIR: test_results
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
       - store_test_results:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:watch": "react-scripts test --watch",
-    "test:ci": "react-scripts test --ci --coverage --reporters=default --reporters=jest-junit",
+    "test:ci": "react-scripts test --ci --coverage --verbose --maxWorkers=2 --reporters=default --reporters=jest-junit",
     "test:coverage": "react-scripts test --ci --coverage",
     "eject": "react-scripts eject",
     "format": "prettier --write \"./**\" --ignore-path .prettierignore",


### PR DESCRIPTION
What
--

* Sets the maximum workers to 2, 
* Set a higher memory

Both a the same settings as portal-frontend to address max worker and time-out errros on pipeline.